### PR TITLE
Add test for get_absolute_url method

### DIFF
--- a/ch6-blog-app-with-forms/blog/tests.py
+++ b/ch6-blog-app-with-forms/blog/tests.py
@@ -23,6 +23,9 @@ class BlogTests(TestCase):
     def test_string_representation(self):
         post = Post(title='A sample title')
         self.assertEqual(str(post), post.title)
+    
+    def test_get_absolute_url(self):
+        self.assertEqual(self.post.get_absolute_url(), '/post/1')
 
     def test_post_content(self):
         self.assertEqual(f'{self.post.title}', 'A good title')


### PR DESCRIPTION
The test is shown in the book v2.2, but I did not see the it in the code samples here. The book states for the user test against an absolute URL of "/post/1/" but that failed. I updated the test to check for "/post/1" without the trailing forward slash and verified that the test passed.