### PR TITLE
Update password_reset_email.html

### DIFF
--- a/ch12-email/templates/registration/password_reset_email.html
+++ b/ch12-email/templates/registration/password_reset_email.html
@@ -1,12 +1,9 @@
 {% load i18n %}{% autoescape off %}
 {% trans "Hi" %} {{ user.get_username }},
 
-{% trans "We've received a request to reset your password. If you didn't make\
-this request, you can safely ignore this email. Otherwise, click the button\
-below to reset your password." %}
+{% blocktrans %}We've received a request to reset your password. If you didn't make this request, you can safely ignore this email. Otherwise, click the button below to reset your password.{% endblocktrans %}
 
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid\
-token=token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock reset_link %}
 {% endautoescape %}


### PR DESCRIPTION
I ran into two issues with the existing code provided in the repository:
1. The password reset link did not render properly due to the backslash
2. The body text should use `{% blocktrans %}{% endblocktrans %}`