### PR TITLE
Test fails without trailing "/"

### DIFF
--- a/ch6-blog-app-with-forms/blog/tests.py
+++ b/ch6-blog-app-with-forms/blog/tests.py
@@ -25,7 +25,7 @@ class BlogTests(TestCase):
         self.assertEqual(str(post), post.title)
     
     def test_get_absolute_url(self):
-        self.assertEqual(self.post.get_absolute_url(), '/post/1')
+        self.assertEqual(self.post.get_absolute_url(), '/post/1/')
 
     def test_post_content(self):
         self.assertEqual(f'{self.post.title}', 'A good title')


### PR DESCRIPTION
The test_get_absolute_url fails without the trailing "/".
This would also match the trailing "/" which was used in the 'post_detail' path in blog/urls.py
This update will match p. 156 in the book.