### PR TITLE
Update password_reset_email.html

### DIFF
--- a/ch12-email/templates/registration/password_reset_email.html
+++ b/ch12-email/templates/registration/password_reset_email.html
@@ -4,8 +4,7 @@ reset for your user account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid
-token=token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
 {% trans 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
 


### PR DESCRIPTION
Just removed the newline. With the newline I get the template tags in the email.

```
You're receiving this email because you requested a password
reset for your user account at 127.0.0.1:8000.

Please go to the following page and choose a new password:


https://<deleted>Rp1xd11eWGK-2FAXg-3D url 'password_reset_confirm' uidb64=uid
token=token %}
```