### PR TITLE
adding new way of appname

### DIFF
--- a/ch2-hello-world-app/django_project/settings.py
+++ b/ch2-hello-world-app/django_project/settings.py
@@ -37,7 +37,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "pages.apps.PagesConfig",  # new
+    # "pages.apps.PagesConfig",  # new
+    'pages'  # directly pass the app name
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
We can mention the path of the app name directly as the app name instead of writing the apps.config.
So please check it whether you like my method and should I continue to make changes accordingly.