### PR TITLE
Removed </ul> from templates/base.html

### DIFF
--- a/ch10-bootstrap/.idea/.gitignore
+++ b/ch10-bootstrap/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/ch10-bootstrap/.idea/ch10-bootstrap.iml
+++ b/ch10-bootstrap/.idea/ch10-bootstrap.iml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="django" name="Django">
+      <configuration>
+        <option name="rootFolder" value="$MODULE_DIR$" />
+        <option name="settingsModule" value="django_project/settings.py" />
+        <option name="manageScript" value="$MODULE_DIR$/manage.py" />
+        <option name="environment" value="&lt;map/&gt;" />
+        <option name="doNotUseTestRunner" value="false" />
+        <option name="trackFilePattern" value="migrations" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Django" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/ch10-bootstrap/.idea/inspectionProfiles/Project_Default.xml
+++ b/ch10-bootstrap/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,30 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="9">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+            <item index="6" class="java.lang.String" itemvalue="ul" />
+            <item index="7" class="java.lang.String" itemvalue="br" />
+            <item index="8" class="java.lang.String" itemvalue="hr" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N802" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/ch10-bootstrap/.idea/inspectionProfiles/profiles_settings.xml
+++ b/ch10-bootstrap/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/ch10-bootstrap/.idea/misc.xml
+++ b/ch10-bootstrap/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (Learning-Django)" project-jdk-type="Python SDK" />
+</project>

--- a/ch10-bootstrap/.idea/modules.xml
+++ b/ch10-bootstrap/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ch10-bootstrap.iml" filepath="$PROJECT_DIR$/.idea/ch10-bootstrap.iml" />
+    </modules>
+  </component>
+</project>

--- a/ch10-bootstrap/.idea/vcs.xml
+++ b/ch10-bootstrap/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/ch10-bootstrap/templates/base.html
+++ b/ch10-bootstrap/templates/base.html
@@ -33,7 +33,7 @@
             </ul>
           </div>
           {% else %}
-          </ul>
+
           <div class="text-end">
             <a href="{% url 'login' %}" class="btn btn-outline-primary me-2">Log In</a>
             <a href="{% url 'signup' %}" class="btn btn-primary">Sign Up</a>


### PR DESCRIPTION
## [Fixes #136] Removed an extra closing `</ul>` tag from djangoforbeginners/ch10-bootstrap/templates/base.html

Before :
<img width="410" alt="Screenshot 2023-01-16 at 7 32 28 PM" src="https://user-images.githubusercontent.com/72253920/212696806-9c397aaa-743c-4459-ac9d-2b07f262c237.png">

After :
<img width="422" alt="Screenshot 2023-01-16 at 7 33 39 PM" src="https://user-images.githubusercontent.com/72253920/212696967-444ffd60-6f63-4953-8748-861c12572506.png">
