### PR TITLE
Remove redundant Login and Sign Up links from home.html

### DIFF
--- a/ch11-newspaper-bootstrap/templates/home.html
+++ b/ch11-newspaper-bootstrap/templates/home.html
@@ -13,7 +13,5 @@ Hi {{ user.username }}! You are {{ user.age }} years old.
 </form>
 {% else %}
 <p>You are not logged in</p>
-<a href="{% url 'login' %}">Log In</a> |
-<a href="{% url 'signup' %}">Sign Up</a>
 {% endif %}
 {% endblock content %}


### PR DESCRIPTION
This PR addresses the redundancy of the Login and Sign Up links in the project.

The **Login** and **Sign Up** links are already included in the `base.html` file for unauthenticated users, specifically in the navigation bar. These links were unintentionally duplicated in `home.html` under the `{% if user.is_authenticated %}` block for unauthenticated users. This redundancy led to unnecessary repetition in the UI.

### Changes:
- **Removed** the duplicate Login and Sign Up links from `home.html`, as they were already being handled by `base.html`.
- This update improves the overall UI by preventing the repetition of these links and ensures that the Login/Sign Up functionality is only shown once in the global navigation.

### Reason for Change:
- The `base.html` template already contains the necessary logic to display Login and Sign Up buttons for unauthenticated users. Therefore, having these links again in `home.html` was redundant and unnecessary.
  
### Result:
- Cleaner and more maintainable code.
- Improved UI with only one set of Login/Sign Up links visible to unauthenticated users.

**Before:**
![image](https://github.com/user-attachments/assets/97bcf48d-0016-478c-833e-3ba8fc3fd0ee)

**After:**
![image](https://github.com/user-attachments/assets/060eb5e4-9351-4870-88ad-9b1cbb6fb20c)
